### PR TITLE
Improve Redirecting With Javascript

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,0 +1,2 @@
+# Make any url show the page that redirects you.
+ErrorDocument 404 /index.html

--- a/index.html
+++ b/index.html
@@ -1,13 +1,10 @@
 <!DOCTYPE html>
 <html>
 <head>
-  <meta charset="UTF-8">
-  <title>Redirecting...</title>
+<title>Redirecting...</title>
+<script>
+var u = "https://caproductions.github.io/home/"
+try{redirectUrl=location.href.split("/"),finalRedirect=[];for(let e=0;e<redirectUrl.length;e++)e>2&&finalRedirect.push(redirectUrl[e]);location.href=u+finalRedirect.join("/");} catch(f) {location.href=u}
+</script>
 </head>
-<body>
-  Redirecting you to <a href="https://CAProductions.github.io/home">https://CAProductions.github.io/home</a>...<br>
-  <script>
-    window.location.href = "https://CAProductions.github.io/home"
-  </script>
-</body>
 </html>


### PR DESCRIPTION
Currently, if you visit `https;//caproductions.github.io/clicker` for example (by accident) then you'll just get a 404 page, which leads to confusion.

Here's my solution: Visiting `https://caproductions.github.io/clicker` redirects you to `https://caproductions.github.io/home/clicker` because of the repo name not being this one's name.

How I did this:
In .htaccess I set the 404 page to be the index.html file. The index.html file will now show whenever you visit *any url* on caproductions.github.io (anything that's not /home/(anything) that is) including just plain old caproductions.github.io. This index.html file will then read the url and find everything after caproductions.github.io/ and redirect you to caproductions.github.io/home/ (whatever came after).

I minified the code so it would run faster btw.